### PR TITLE
2 bug fixes: typo task.reminder & returning task.subtasks in correct …

### DIFF
--- a/lib/wunderlist/task.rb
+++ b/lib/wunderlist/task.rb
@@ -69,7 +69,7 @@ module Wunderlist
     def reminder
       res = self.api.request :get, 'api/v1/reminders', {:task_id => self.id}
       if !res[0].nil?
-        reminder = Wunderlist::Rminder.new(res[0])
+        reminder = Wunderlist::Reminder.new(res[0])
       else
         reminder = Wunderlist::Reminder.new('task_id' => self.id)
       end
@@ -100,7 +100,8 @@ module Wunderlist
         subtasks << subtask
       end
 
-      subtasks
+      #This will return tasks in backwards order, so reverse them
+      subtasks.reverse
 
     end
 


### PR DESCRIPTION
Hi there!
As I've been developing a Wunderlist command-line interface (and simple file format for mass uploading from text files) I found two small bugs in the excellent Wunderlist API you created:
1) There is a typo in task.reminder that was throwing an error in some circumstances.
2) task.subtasks were being returned in backwards order.
I've fixed both bugs. Please have a look and incorporate the fixes if you find them useful. :)
I think we emailed a while ago about doing some development of a Wunderlist CLI together - sorry the progress is so slow. ;)
Thanks and best regards,
Arnaldo
