### PR TITLE
Include `created_at` property in the task

### DIFF
--- a/lib/wunderlist/task.rb
+++ b/lib/wunderlist/task.rb
@@ -18,6 +18,7 @@ module Wunderlist
       @title = attrs['title']
       @revision = attrs['revision']
       @assignee_id = attrs['assignee_id']
+      @created_at = attrs['created_at']
       @completed = attrs['completed']
       @completed_at = attrs['completed_at']
       @completed_by_id = attrs['completed_by_id']

--- a/spec/wunderlist/task_spec.rb
+++ b/spec/wunderlist/task_spec.rb
@@ -12,6 +12,7 @@ describe Wunderlist::Task do
         title
         revision
         assignee_id
+        created_at
         completed
         completed_at
         completed_by_id


### PR DESCRIPTION
I needed to access the `created_at` property on the task and noticed it was missing from here.